### PR TITLE
fix admin form_fields()

### DIFF
--- a/wc-ecard-payment-gateway/class-wc-payment-ecard.php
+++ b/wc-ecard-payment-gateway/class-wc-payment-ecard.php
@@ -25,7 +25,7 @@ function init_Ecard_gateway() {
 			
 			global $woocommerce;
 			
-			$this->id = __('Ecard', 'woocommerce');
+			$this->id = 'ecard';
 			$this->has_fields = false;
 			$this->method_title = __('eCard', 'woocommerce');
 			$this->notify_link = str_replace('https:', 'http:', add_query_arg('wc-api', 'WC_Gateway_Ecard', home_url('/')));


### PR DESCRIPTION
form_fields() function wont print form in admin panel, if you have ID started with uppercase.

Tested on wordpres 4.5.3, woocommerce 2.6.2.
